### PR TITLE
Fix UV install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Get up and running with AI-SDLC in under 2 minutes:
 
 ```bash
 # Install uv (fast Python package manager)
-curl -LsSf https://astral.sh/uv/install | sh
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Install AI-SDLC
 uv pip install ai-sdlc


### PR DESCRIPTION
Fixes the UV install command (addresses https://github.com/Vibe-with-AI/ai-sdlc/issues/7)